### PR TITLE
Adds duration prop to modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ export default Example;
 * keyboard - Receive a callback function or a boolean to choose to close the modal when escape key is pressed.
 * backdrop - Includes a backdrop element.
 * closeOnClick - Close the backdrop element when clicked.
+* duration - duration in milliseconds before the modal is hidden
 * onShow - Show callback.
 * onHide - Hide callback. Argument is the source of the hide action, one of:
   * hide - hide() method is the cause of the hide.
   * toggle - toggle() method is the cause of the hide
   * keyboard - keyboard (escape key) is the cause of the hide
   * backdrop - backdrop click is the cause of the hide
+  * timeout - timeout is the cause of the hide
   * [any] - custom argument passed by invoking code into the hide() method when called directly.
 * modalStyle - CSS styles to apply to the modal
 * backdropStyle - CSS styles to apply to the backdrop

--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -107,6 +107,9 @@ export default (animation) => {
     };
 
     enter() {
+      if (this.props.duration >= 0)
+        setTimeout(() => this.hide("timeout"), parseInt(this.props.duration));
+
       this.props.onShow();
     };
 
@@ -164,6 +167,7 @@ export default (animation) => {
   Factory.propTypes = {
     className: PropTypes.string,
     keyboard: PropTypes.bool,
+    duration: PropTypes.number,
     onShow: PropTypes.func,
     onHide: PropTypes.func,
     animation: PropTypes.object,
@@ -176,6 +180,7 @@ export default (animation) => {
 
   Factory.defaultProps = {
     className: '',
+    duration: -1,
     onShow: function(){},
     onHide: function(){},
     animation: animation,


### PR DESCRIPTION
Adds prop `duration` in milliseconds before a modal hides itself.

Value of undefined or -1 naturally does not trigger a hide()

`<FadeModal ref="TaskComplete" duration={5000} />`